### PR TITLE
Test New LLMs (Llama2, CodeLlama, etc.) on Chat-UI?

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,17 @@
+# Test New LLMs (CodeLlama, Llama2, etc.) 
+
+Notice you forked chat-ui. if you're trying to test other LLMs (codellama, wizardcoder, etc.) with it, I just wrote a [1-click proxy](https://github.com/BerriAI/litellm#openai-proxy-server) to translate openai calls to huggingface, anthropic, togetherai, etc. api calls.
+
+**code**
+```
+$ pip install litellm
+$ litellm --model huggingface/bigcode/starcoder
+#INFO:     Uvicorn running on http://0.0.0.0:8000
+$ aider --openai-api-base http://0.0.0.0:8000
+```
+
+I'd love to know if this solves a problem for you
+
 ---
 title: chat-ui
 emoji: 🔥


### PR DESCRIPTION
Hi @John-Abdelsayed,

Notice you forked chat-ui. if you're trying to test other LLMs (codellama, wizardcoder, etc.) with it, I just wrote a [1-click proxy](https://github.com/BerriAI/litellm#openai-proxy-server) to translate openai calls to huggingface, anthropic, togetherai, etc. api calls.

**code**
```
$ pip install litellm

$ litellm --model huggingface/bigcode/starcoder

#INFO:     Uvicorn running on http://0.0.0.0:8000

>> openai.api_base = "http://0.0.0.0:8000"
```

Here's the PR on adding openai to chat-ui: https://github.com/huggingface/chat-ui/pull/452

I'd love to know if this solves a problem for you